### PR TITLE
Fixed a major bug

### DIFF
--- a/Azure/src/Azure2D.cpp
+++ b/Azure/src/Azure2D.cpp
@@ -47,14 +47,13 @@ void Azure2D::OnUpdate(Blu::Timestep deltaTime)
 	BLU_PROFILE_FUNCTION();
 	{
 
-		BLU_PROFILE_SCOPE("Azure2D::OnUpdate: ")
-		m_CameraController.OnUpdate(deltaTime);
+		
 	}
 	
 	Blu::RenderCommand::SetClearColor({ 0.1f, 0.1f, 0.1f, 1 });
 	Blu::RenderCommand::Clear();
 	
-	Blu::Renderer2D::BeginScene(m_CameraController.GetCamera()); 
+	//Blu::Renderer2D::BeginScene(m_CameraController.GetCamera()); 
 	
 	m_ParticleProps.Position = glm::vec2( (m_MousePosX/ 100.f) -8 , -m_MousePosY /100.0f + 5);
 
@@ -73,7 +72,7 @@ void Azure2D::OnUpdate(Blu::Timestep deltaTime)
 
 	
 
-	Blu::Renderer2D::EndScene();
+	//Blu::Renderer2D::EndScene();
 	m_FrameBuffer->UnBind();
 
 	 

--- a/Blu-Editor/imgui.ini
+++ b/Blu-Editor/imgui.ini
@@ -50,13 +50,13 @@ DockId=0x00000006,2
 
 [Window][Scene Hierarchy]
 Pos=0,24
-Size=270,701
+Size=270,590
 Collapsed=0
 DockId=0x00000009,0
 
 [Window][Properties]
-Pos=0,727
-Size=270,334
+Pos=0,616
+Size=270,445
 Collapsed=0
 DockId=0x0000000A,0
 
@@ -73,8 +73,8 @@ Column 1  Weight=1.0000
 DockSpace         ID=0x08BE5674 Window=0x825DC150 Pos=0,24 Size=1920,1037 Split=X
   DockNode        ID=0x00000007 Parent=0x08BE5674 SizeRef=1008,990 Split=X
     DockNode      ID=0x00000001 Parent=0x00000007 SizeRef=270,701 Split=Y Selected=0x2E9237F7
-      DockNode    ID=0x00000009 Parent=0x00000001 SizeRef=431,701 Selected=0x2E9237F7
-      DockNode    ID=0x0000000A Parent=0x00000001 SizeRef=431,334 Selected=0x199AB496
+      DockNode    ID=0x00000009 Parent=0x00000001 SizeRef=431,590 Selected=0x2E9237F7
+      DockNode    ID=0x0000000A Parent=0x00000001 SizeRef=431,445 Selected=0x199AB496
     DockNode      ID=0x00000002 Parent=0x00000007 SizeRef=1376,701 Split=Y
       DockNode    ID=0x00000005 Parent=0x00000002 SizeRef=541,351 Split=Y Selected=0x13926F0B
         DockNode  ID=0x00000003 Parent=0x00000005 SizeRef=807,351 CentralNode=1 Selected=0x13926F0B

--- a/Blu-Editor/src/BluEditorLayer.cpp
+++ b/Blu-Editor/src/BluEditorLayer.cpp
@@ -102,19 +102,19 @@ namespace Blu
 		}
 		
 		m_ActiveScene->OnUpdate(deltaTime);
-		m_ParticleProps.Position = glm::vec2((m_MousePosX / 100.f) - 8, -m_MousePosY / 100.0f + 5);
+		/*m_ParticleProps.Position = glm::vec2((m_MousePosX / 100.f) - 8, -m_MousePosY / 100.0f + 5);
 
 
 		m_ParticleSystem.Emit(m_ParticleProps);
 		m_ParticleSystem.OnUpdate(deltaTime);
 
-		m_ParticleSystem.OnRender();
+		m_ParticleSystem.OnRender();*/
 		
-		static float rotation = 0.0f;
+		/*static float rotation = 0.0f;
 		rotation += deltaTime * 150.0f;
 		Renderer2D::DrawRotatedQuad({ -1, 0 }, { 1, 1 }, glm::radians(rotation), { 1.0f ,1.0f ,0.0f ,1.0f });
 
-		Renderer2D::DrawQuad({ 0.0f, 0.0f }, { 1.0f, 1.0f }, m_Texture);
+		Renderer2D::DrawQuad({ 0.0f, 0.0f }, { 1.0f, 1.0f }, m_Texture);*/
 
 
 

--- a/Blu/engine/src/Blu/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/Blu/engine/src/Blu/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -1,6 +1,7 @@
 #include "Blupch.h"
 #include "OpenGLRendererAPI.h"
 #include <glad/glad.h>
+#include "Blu/Core/Log.h"
 
 
 namespace Blu
@@ -11,8 +12,15 @@ namespace Blu
 	}
 	void OpenGLRendererAPI::DrawIndexed(const Shared<VertexArray>& vertexArray, uint32_t indexCount)
 	{
+		if (indexCount == 0)
+		{
+			// No indices to draw, so return early
+			return;
+		}
+
 		uint32_t count = indexCount ? indexCount : vertexArray->GetIndexBuffer()->GetCount();
 		glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, nullptr);
+		BLU_CORE_ERROR("Drawing Quad");
 	}
 	void OpenGLRendererAPI::SetViewport(uint32_t x, uint32_t y, uint32_t width, uint32_t height)
 	{

--- a/Blu/engine/src/Blu/Rendering/Renderer2D.h
+++ b/Blu/engine/src/Blu/Rendering/Renderer2D.h
@@ -39,6 +39,7 @@ namespace Blu
 			uint32_t DrawCalls = 0;
 			uint32_t QuadCount = 0;
 
+
 			uint32_t GetTotalVertexCount() { return QuadCount * 4; }
 			uint32_t GetTotalIndexCount() { return QuadCount * 6; }
 			

--- a/Blu/engine/src/Blu/Scene/Scene.cpp
+++ b/Blu/engine/src/Blu/Scene/Scene.cpp
@@ -40,7 +40,11 @@ namespace Blu
 						nsc.Instance->m_Entity = Entity{ entity, this };
 						nsc.Instance->OnCreate();
 					}
-					nsc.Instance->OnUpdate(deltaTime);
+					if (nsc.Instance)
+					{
+						nsc.Instance->OnUpdate(deltaTime);	
+
+					}
 				});
 		}
 		Camera* mainCamera = nullptr;
@@ -66,6 +70,7 @@ namespace Blu
 			{
 				auto [transform, sprite] = group.get<TransformComponent, SpriteRendererComponent>(entity);
 				Renderer2D::DrawQuad(transform.GetTransform(), sprite.Color);
+				
 			}
 			Renderer2D::EndScene();
 		}


### PR DESCRIPTION
if (indexCount == 0)
		{
			// No indices to draw, so return early
			return;
		}

		uint32_t count = indexCount ? indexCount : vertexArray->GetIndexBuffer()->GetCount();
		glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, nullptr);

added the if check that now allows for the program to not draw any quads if no sprite renderer component is present. The bug manifested itself if i removed the sprite render component if there was only one in the scene, it removed the component but the quad was still being shown